### PR TITLE
Support for Bankscrap v2.0.0

### DIFF
--- a/bankscrap-ing.gemspec
+++ b/bankscrap-ing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'bankscrap',   '~> 1.0'
+  spec.add_runtime_dependency 'bankscrap',   '~> 2.0.0'
   spec.add_runtime_dependency 'rmagick',     '~> 2.2', '>= 2.2.2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/bankscrap/ing/bank.rb
+++ b/lib/bankscrap/ing/bank.rb
@@ -18,6 +18,8 @@ module Bankscrap
       SAMPLE_HEIGHT    = 30
       SAMPLE_ROOT_PATH = '/numbers'.freeze
 
+      REQUIRED_CREDENTIALS  = [:nif, :password, :birthday]
+
       def initialize(credentials = {})
         super do
           @password = @password.to_s
@@ -103,7 +105,7 @@ module Bankscrap
         params = {
           loginDocument: {
             documentType: 0,
-            document: @dni.to_s
+            document: @nif
           },
           birthday: @birthday.to_s,
           companyDocument: nil,

--- a/lib/bankscrap/ing/bank.rb
+++ b/lib/bankscrap/ing/bank.rb
@@ -18,7 +18,7 @@ module Bankscrap
       SAMPLE_HEIGHT    = 30
       SAMPLE_ROOT_PATH = '/numbers'.freeze
 
-      REQUIRED_CREDENTIALS  = [:nif, :password, :birthday]
+      REQUIRED_CREDENTIALS  = [:dni, :password, :birthday]
 
       def initialize(credentials = {})
         super do
@@ -105,7 +105,7 @@ module Bankscrap
         params = {
           loginDocument: {
             documentType: 0,
-            document: @nif
+            document: @dni
           },
           birthday: @birthday.to_s,
           companyDocument: nil,

--- a/lib/bankscrap/ing/bank.rb
+++ b/lib/bankscrap/ing/bank.rb
@@ -201,9 +201,8 @@ module Bankscrap
           bank: self,
           id: data['uuid'],
           name: data['name'],
-          balance: data['balance'],
-          currency: 'EUR',
-          available_balance: data['availableBalance'],
+          balance: Money.new(data['balance'] * 100, 'EUR'),
+          available_balance: Money.new(data['availableBalance'] * 100, 'EUR'),
           description: (data['alias'] || data['name']),
           iban: data['iban'],
           bic: data['bic']
@@ -228,10 +227,9 @@ module Bankscrap
           account: account,
           id: data['uuid'],
           amount: amount,
-          currency: data['EUR'],
           effective_date: Date.strptime(data['effectiveDate'], '%d/%m/%Y'),
           description: data['description'],
-          balance: data['balance']
+          balance: Money.new(data['balance'] * 100, 'EUR')
         )
       end
     end

--- a/lib/bankscrap/ing/bank.rb
+++ b/lib/bankscrap/ing/bank.rb
@@ -18,19 +18,10 @@ module Bankscrap
       SAMPLE_HEIGHT    = 30
       SAMPLE_ROOT_PATH = '/numbers'.freeze
 
-      def initialize(user, password, log: false, debug: false, extra_args:)
-        @dni      = user
-        @password = password.to_s
-        @birthday = extra_args.with_indifferent_access['birthday']
-        @log      = log
-        @debug    = debug
-
-        initialize_connection
-        bundled_login
-
-        @investments = fetch_investments
-
-        super
+      def initialize(credentials = {})
+        super do
+          @password = @password.to_s
+        end
       end
 
       def balances
@@ -97,13 +88,13 @@ module Bankscrap
 
       private
 
-      def bundled_login
-        selected_positions = login
+      def login
+        selected_positions = get_pin_pad_positions
         ticket = pass_pinpad(selected_positions)
         post_auth(ticket)
       end
 
-      def login
+      def get_pin_pad_positions
         add_headers(
           'Accept'       => 'application/json, text/javascript, */*; q=0.01',
           'Content-Type' => 'application/json; charset=utf-8'

--- a/lib/bankscrap/ing/version.rb
+++ b/lib/bankscrap/ing/version.rb
@@ -1,5 +1,5 @@
 module Bankscrap
   module ING
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end


### PR DESCRIPTION
- Refactored initialize
- Renamed `dni` to `nif`
- Renamed bundle_login, as now the `initialize` method in the base `Bank` class is already calling `login`.
- Build account and transaction using money objects

@raulmarcosl I did the required changes to support the new `Bank#initialize` from Bankscrap `v2.0.0`, however I can't test them as I don't have an ING account. Can you test it and merge it if everything is ok?

Make sure to also test fetching investments. Thanks!

Also, this adapter is always returning accounts and transactions with `EUR` as currency. Can we get that data from the API?
